### PR TITLE
Fix PHP notice and only output customizer templates if we're serving Publishing Flow

### DIFF
--- a/inc/class-publishing-flow-admin.php
+++ b/inc/class-publishing-flow-admin.php
@@ -719,7 +719,13 @@ class Publishing_Flow_Admin {
 	 */
 	public function customize_controls_print_footer_scripts() {
 
-		$post_id = (int)$_GET['post-id'];
+		$post_id         = ( isset( $_GET['post-id'] ) ) ? (int)$_GET['post-id'] : 0;
+		$publishing_flow = ( isset( $_GET['publishing-flow'] ) && 'true' === $_GET['publishing-flow'] );
+
+		// Bail if we're not serving Publishing Flow.
+		if ( empty( $post_id ) || empty( $publishing_flow ) ) {
+			return;
+		}
 
 		// Templates.
 		$templates = array(


### PR DESCRIPTION
This PR fixes the following PHP notice:

```
PHP Notice:  Undefined index: post-id in /srv/wp/wp-content/plugins/publishing-flow/inc/class-publishing-flow-admin.php on line 722
```

And it restricts outputting our JS templates to only when Publishing Flow is being served.
