### PR TITLE
Improve discoverability of required fields toggle on Post edit screens and cut 1.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Tags:** publishing, flow, required, fields, preview  
 **Requires at least:** 4.5  
 **Tested up to:** 4.6  
-**Stable tag:** 1.1.1  
+**Stable tag:** 1.1.2  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -222,6 +222,9 @@ function xxx_data_array( $data ) {
 
 ## Changelog ##
 
+### 1.1.2 ###
+* Update styling of required fields toggle in the Publish box on Post edit screens to improve discoverability
+
 ### 1.1.1 ###
 * Fix for compatibility issue with Edit Flow version 0.8.1 and older
 
@@ -234,6 +237,9 @@ function xxx_data_array( $data ) {
 * Initial release.
 
 ## Upgrade Notice ##
+
+### 1.1.2 ###
+* Update styling of required fields toggle in the Publish box on Post edit screens to improve discoverability
 
 ### 1.1.1 ###
 * Fix for compatibility issue with Edit Flow version 0.8.1 and older

--- a/css/publishing-flow-admin.css
+++ b/css/publishing-flow-admin.css
@@ -30,12 +30,25 @@
 	color: red;
 }
 
-.publishing-flow-requirements-status .dashicons-arrow-down {
+.publishing-flow-requirements-status .dashicons-arrow-down,
+.publishing-flow-requirements-status .dashicons-arrow-up {
+	float: right;
+}
+
+.publishing-flow-requirements-status .dashicons-arrow-up {
 	display: none;
 }
 
-.publishing-flow-requirements-status:hover .dashicons-arrow-down {
+.publishing-flow-requirements-status .dashicons-arrow-down {
 	display: inline-block;
+}
+
+.publishing-flow-requirements-wrap.active .publishing-flow-requirements-status .dashicons-arrow-up {
+	display: inline-block;
+}
+
+.publishing-flow-requirements-wrap.active .publishing-flow-requirements-status .dashicons-arrow-down {
+	display: none;
 }
 
 .publishing-flow-requirements-wrap .pf-section {

--- a/inc/class-publishing-flow-admin.php
+++ b/inc/class-publishing-flow-admin.php
@@ -131,21 +131,24 @@ class Publishing_Flow_Admin {
 
 		$data = $this->build_data_array( $post->ID );
 
+		$icon_down = '<span class="dashicons dashicons-arrow-down"></span>';
+		$icon_up = '<span class="dashicons dashicons-arrow-up"></span>';
+
 		if ( $data['requirementsMet'] ) {
 			$output = sprintf(
-				'<span class="%s"></span>%s<span class="%s"></span>',
+				'<span class="%s"></span>%s',
 				'dashicons dashicons-yes',
-				__( 'All required fields have a value', 'publishing-flow' ),
-				'dashicons dashicons-arrow-down'
+				__( 'All required fields have a value', 'publishing-flow' )
 			);
 		} else {
 			$output = sprintf(
-				'<span class="%s"></span>%s<span class="%s"></span>',
+				'<span class="%s"></span>%s',
 				'dashicons dashicons-no-alt',
-				__( 'Required fields are missing values', 'publishing-flow' ),
-				'dashicons dashicons-arrow-down'
+				__( 'Required fields are missing values', 'publishing-flow' )
 			);
 		}
+
+		$output .= $icon_down . $icon_up;
 
 		$output = sprintf(
 			'<div class="%s"><div class="%s">%s</div></div>',

--- a/languages/publishing-flow.pot
+++ b/languages/publishing-flow.pot
@@ -1,14 +1,14 @@
-# Copyright (C) 2016 Braad Martin
+# Copyright (C) 2017 Braad Martin
 # This file is distributed under the same license as the Publishing Flow package.
 msgid ""
 msgstr ""
-"Project-Id-Version: Publishing Flow 1.1.1\n"
+"Project-Id-Version: Publishing Flow 1.1.2\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/publishing-flow\n"
-"POT-Creation-Date: 2016-08-08 21:50:01+00:00\n"
+"POT-Creation-Date: 2017-10-23 19:47:34+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2016-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2017-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "X-Generator: grunt-wp-i18n 0.5.4\n"
@@ -24,163 +24,163 @@ msgstr ""
 "X-Poedit-Bookmarks: \n"
 "X-Textdomain-Support: yes\n"
 
-#: inc/class-publishing-flow-admin.php:138
+#: inc/class-publishing-flow-admin.php:141
 msgid "All required fields have a value"
 msgstr ""
 
-#: inc/class-publishing-flow-admin.php:145
+#: inc/class-publishing-flow-admin.php:147
 msgid "Required fields are missing values"
 msgstr ""
 
-#: inc/class-publishing-flow-admin.php:602
+#: inc/class-publishing-flow-admin.php:605
 msgid "Publish Flow"
 msgstr ""
 
-#: inc/class-publishing-flow-admin.php:603
+#: inc/class-publishing-flow-admin.php:606
 msgid "Schedule Flow"
 msgstr ""
 
-#: inc/class-publishing-flow-admin.php:604
+#: inc/class-publishing-flow-admin.php:607
 msgid "Publish"
 msgstr ""
 
-#: inc/class-publishing-flow-admin.php:605
+#: inc/class-publishing-flow-admin.php:608
 msgid "Schedule"
 msgstr ""
 
-#: inc/class-publishing-flow-admin.php:606
+#: inc/class-publishing-flow-admin.php:609
 msgid "Required"
 msgstr ""
 
-#: inc/class-publishing-flow-admin.php:607
+#: inc/class-publishing-flow-admin.php:610
 msgid "Optional"
 msgstr ""
 
-#: inc/class-publishing-flow-admin.php:608
+#: inc/class-publishing-flow-admin.php:611
 msgid "Publish Date"
 msgstr ""
 
-#: inc/class-publishing-flow-admin.php:609
+#: inc/class-publishing-flow-admin.php:612
 msgid "This post will be published"
 msgstr ""
 
-#: inc/class-publishing-flow-admin.php:610
+#: inc/class-publishing-flow-admin.php:613
 msgid "This post will be scheduled to publish on"
 msgstr ""
 
-#: inc/class-publishing-flow-admin.php:611
+#: inc/class-publishing-flow-admin.php:614
 msgid "This post will be published with a date in the past on"
 msgstr ""
 
-#: inc/class-publishing-flow-admin.php:612
+#: inc/class-publishing-flow-admin.php:615
 msgid "immediately"
 msgstr ""
 
-#: inc/class-publishing-flow-admin.php:613
+#: inc/class-publishing-flow-admin.php:616
 msgid "Welcome to Publishing Flow"
 msgstr ""
 
-#: inc/class-publishing-flow-admin.php:614
+#: inc/class-publishing-flow-admin.php:617
 msgid ""
 "Before you can publish you'll need to click through each of the device "
 "preview icons on the bottom of this panel"
 msgstr ""
 
-#: inc/class-publishing-flow-admin.php:615
+#: inc/class-publishing-flow-admin.php:618
 msgid "Woah there, looks like this post is still missing a required field!"
 msgstr ""
 
-#: inc/class-publishing-flow-admin.php:616
+#: inc/class-publishing-flow-admin.php:619
 msgid "Visit the edit screen to fix this."
 msgstr ""
 
-#: inc/class-publishing-flow-admin.php:617
+#: inc/class-publishing-flow-admin.php:620
 msgid ""
 "Woah there, looks like you haven't yet previewed this post on all screen "
 "sizes."
 msgstr ""
 
-#: inc/class-publishing-flow-admin.php:618
+#: inc/class-publishing-flow-admin.php:621
 msgid "Click through each device"
 msgstr ""
 
-#: inc/class-publishing-flow-admin.php:776
-#: inc/class-publishing-flow-admin.php:806
+#: inc/class-publishing-flow-admin.php:785
+#: inc/class-publishing-flow-admin.php:815
 msgid "Success!"
 msgstr ""
 
-#: inc/class-publishing-flow-admin.php:779
+#: inc/class-publishing-flow-admin.php:788
 msgid "Your post has been published."
 msgstr ""
 
-#: inc/class-publishing-flow-admin.php:781
-#: inc/class-publishing-flow-admin.php:815
+#: inc/class-publishing-flow-admin.php:790
+#: inc/class-publishing-flow-admin.php:824
 msgid "What do you want to do now?"
 msgstr ""
 
-#: inc/class-publishing-flow-admin.php:782
-#: inc/class-publishing-flow-admin.php:816
+#: inc/class-publishing-flow-admin.php:791
+#: inc/class-publishing-flow-admin.php:825
 msgid "View Post"
 msgstr ""
 
-#: inc/class-publishing-flow-admin.php:783
-#: inc/class-publishing-flow-admin.php:817
+#: inc/class-publishing-flow-admin.php:792
+#: inc/class-publishing-flow-admin.php:826
 msgid "Keep Editing"
 msgstr ""
 
-#: inc/class-publishing-flow-admin.php:811
+#: inc/class-publishing-flow-admin.php:820
 msgid "Your post has been scheduled to publish on"
 msgstr ""
 
-#: inc/class-publishing-flow-admin.php:838
+#: inc/class-publishing-flow-admin.php:847
 msgid "Whoops, something went wrong..."
 msgstr ""
 
-#: inc/class-publishing-flow-admin.php:841
+#: inc/class-publishing-flow-admin.php:850
 msgid "Your post could not be published or scheduled at this time."
 msgstr ""
 
-#: inc/class-publishing-flow-admin.php:843
+#: inc/class-publishing-flow-admin.php:852
 msgid "Please go back to the edit screen and try again."
 msgstr ""
 
-#: inc/class-publishing-flow-admin.php:844
+#: inc/class-publishing-flow-admin.php:853
 msgid "Return to Edit Screen"
 msgstr ""
 
-#: inc/class-publishing-flow-admin.php:866
+#: inc/class-publishing-flow-admin.php:875
 msgid "Sorry, the current user is not allowed to publish posts"
 msgstr ""
 
-#: inc/class-publishing-flow-admin.php:880
+#: inc/class-publishing-flow-admin.php:889
 msgid "Sorry, no post to publish was found."
 msgstr ""
 
-#: inc/class-publishing-flow-admin.php:892
+#: inc/class-publishing-flow-admin.php:901
 msgid "Looks like this post has already been published or scheduled"
 msgstr ""
 
-#: inc/class-publishing-flow-admin.php:974
+#: inc/class-publishing-flow-admin.php:983
 msgid "Post Title"
 msgstr ""
 
-#: inc/class-publishing-flow-admin.php:976
+#: inc/class-publishing-flow-admin.php:985
 msgid "The post has a title"
 msgstr ""
 
-#: inc/class-publishing-flow-admin.php:977
+#: inc/class-publishing-flow-admin.php:986
 msgid "The post is missing a title"
 msgstr ""
 
-#: inc/class-publishing-flow-admin.php:980
+#: inc/class-publishing-flow-admin.php:989
 msgid "Post Content"
 msgstr ""
 
-#: inc/class-publishing-flow-admin.php:982
+#: inc/class-publishing-flow-admin.php:991
 msgid "The post has content"
 msgstr ""
 
-#: inc/class-publishing-flow-admin.php:983
+#: inc/class-publishing-flow-admin.php:992
 msgid "The post is missing content"
 msgstr ""
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 
 {
   "name": "publishing-flow",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "main": "Gruntfile.js",
   "author": "Braad Martin",
   "devDependencies": {

--- a/publishing-flow.php
+++ b/publishing-flow.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Publishing Flow
- * Version:     1.1.1
+ * Version:     1.1.2
  * Description: Adds a Customizer-based publishing flow for ensuring posts are complete before publishing
  * Author:      Braad Martin
  * Author URI:  http://braadmartin.com
@@ -10,7 +10,7 @@
  * Domain Path: /languages
  */
 
-define( 'PUBLISHING_FLOW_VERSION', '1.1.1' );
+define( 'PUBLISHING_FLOW_VERSION', '1.1.2' );
 define( 'PUBLISHING_FLOW_PATH', plugin_dir_path( __FILE__ ) );
 define( 'PUBLISHING_FLOW_URL', plugin_dir_url( __FILE__ ) );
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: http://braadmartin.com/
 Tags: publishing, flow, required, fields, preview
 Requires at least: 4.5
 Tested up to: 4.6
-Stable tag: 1.1.1
+Stable tag: 1.1.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -222,6 +222,9 @@ function xxx_data_array( $data ) {
 
 == Changelog ==
 
+= 1.1.2 =
+* Update styling of required fields toggle in the Publish box on Post edit screens to improve discoverability
+
 = 1.1.1 =
 * Fix for compatibility issue with Edit Flow version 0.8.1 and older
 
@@ -234,6 +237,9 @@ function xxx_data_array( $data ) {
 * Initial release.
 
 == Upgrade Notice ==
+
+= 1.1.2 =
+* Update styling of required fields toggle in the Publish box on Post edit screens to improve discoverability
 
 = 1.1.1 =
 * Fix for compatibility issue with Edit Flow version 0.8.1 and older


### PR DESCRIPTION
Previously we only showed a down arrow icon when the Required fields toggle was hovered on Post edit screens. I've gotten reports of this leading to discoverability issues, so in this PR we switch to always displaying a down arrow and changing it to an up array when the toggle is open.