### PR TITLE
Check length of property value to not show true on empty arrays

### DIFF
--- a/templates/optional-group.php
+++ b/templates/optional-group.php
@@ -2,7 +2,7 @@
 	<div class="pf-optional-group pf-field pf-key-{{ data.key }}" data-key="{{ data.key }}">
 		<div class="pf-label">
 			<h3>{{ data.label }}</h3>
-			<# if ( data.value ) { #>
+			<# if ( data.value.length ) { #>
 				<div class="pf-all-good pf-status">
 					<span class="dashicons dashicons-yes"></span>
 				</div>
@@ -12,11 +12,11 @@
 				</div>
 			<# } #>
 		</div>
-		<# if ( data.value && data.showValue ) { #>
+		<# if ( data.value.length && data.showValue ) { #>
 			<div class="pf-value pf-has-value">
 				<p>{{ data.value }}</p>
 			</div>
-		<# } else if ( data.value && data.hasValue ) { #>
+		<# } else if ( data.value.length && data.hasValue ) { #>
 			<div class="pf-value pf-has-value">
 				<p>{{ data.hasValue }}</p>
 			</div>
@@ -24,7 +24,7 @@
 			<div class="pf-value pf-no-value">
 				<p>{{ data.noValue }}</p>
 			</div>
-		<# } else if ( data.value ) { #>
+		<# } else if ( data.value.length ) { #>
 			<div class="pf-value">
 				<p>Value: {{ data.value }}</p>
 			</div>

--- a/templates/optional-meta.php
+++ b/templates/optional-meta.php
@@ -2,7 +2,7 @@
 	<div class="pf-optional-meta pf-field pf-key-{{ data.key }}" data-key="{{ data.key }}">
 		<div class="pf-label">
 			<h3>{{ data.label }}</h3>
-			<# if ( data.value ) { #>
+			<# if ( data.value.length ) { #>
 				<div class="pf-all-good pf-status">
 					<span class="dashicons dashicons-yes"></span>
 				</div>
@@ -12,11 +12,11 @@
 				</div>
 			<# } #>
 		</div>
-		<# if ( data.value && data.showValue ) { #>
+		<# if ( data.value.length && data.showValue ) { #>
 			<div class="pf-value pf-has-value">
 				<p>{{ data.value }}</p>
 			</div>
-		<# } else if ( data.value && data.hasValue ) { #>
+		<# } else if ( data.value.length && data.hasValue ) { #>
 			<div class="pf-value pf-has-value">
 				<p>{{ data.hasValue }}</p>
 			</div>
@@ -24,7 +24,7 @@
 			<div class="pf-value pf-no-value">
 				<p>{{ data.noValue }}</p>
 			</div>
-		<# } else if ( data.value ) { #>
+		<# } else if ( data.value.length ) { #>
 			<div class="pf-value">
 				<p>Value: {{ data.value }}</p>
 			</div>

--- a/templates/optional-primary.php
+++ b/templates/optional-primary.php
@@ -2,7 +2,7 @@
 	<div class="pf-optional-primary pf-field pf-key-{{ data.key }}" data-key="{{ data.key }}">
 		<div class="pf-label">
 			<h3>{{ data.label }}</h3>
-			<# if ( data.value ) { #>
+			<# if ( data.value.length ) { #>
 				<div class="pf-all-good pf-status">
 					<span class="dashicons dashicons-yes"></span>
 				</div>
@@ -12,11 +12,11 @@
 				</div>
 			<# } #>
 		</div>
-		<# if ( data.value && data.showValue ) { #>
+		<# if ( data.value.length && data.showValue ) { #>
 			<div class="pf-value pf-has-value">
 				<p>{{ data.value }}</p>
 			</div>
-		<# } else if ( data.value && data.hasValue ) { #>
+		<# } else if ( data.value.length && data.hasValue ) { #>
 			<div class="pf-value pf-has-value">
 				<p>{{ data.hasValue }}</p>
 			</div>
@@ -24,7 +24,7 @@
 			<div class="pf-value pf-no-value">
 				<p>{{ data.noValue }}</p>
 			</div>
-		<# } else if ( data.value ) { #>
+		<# } else if ( data.value.length ) { #>
 			<div class="pf-value">
 				<p>Value: {{ data.value }}</p>
 			</div>

--- a/templates/optional-taxonomy.php
+++ b/templates/optional-taxonomy.php
@@ -2,7 +2,7 @@
 	<div class="pf-optional-tax pf-field pf-key-{{ data.key }}" data-key="{{ data.key }}">
 		<div class="pf-label">
 			<h3>{{ data.label }}</h3>
-			<# if ( data.value ) { #>
+			<# if ( data.value.length ) { #>
 				<div class="pf-all-good pf-status">
 					<span class="dashicons dashicons-yes"></span>
 				</div>
@@ -12,11 +12,11 @@
 				</div>
 			<# } #>
 		</div>
-		<# if ( data.value && data.showValue ) { #>
+		<# if ( data.value.length && data.showValue ) { #>
 			<div class="pf-value pf-has-value">
 				<p>{{ data.value }}</p>
 			</div>
-		<# } else if ( data.value && data.hasValue ) { #>
+		<# } else if ( data.value.length && data.hasValue ) { #>
 			<div class="pf-value pf-has-value">
 				<p>{{ data.hasValue }}</p>
 			</div>
@@ -24,7 +24,7 @@
 			<div class="pf-value pf-no-value">
 				<p>{{ data.noValue }}</p>
 			</div>
-		<# } else if ( data.value ) { #>
+		<# } else if ( data.value.length ) { #>
 			<div class="pf-value">
 				<p>Value: {{ data.value }}</p>
 			</div>

--- a/templates/required-group.php
+++ b/templates/required-group.php
@@ -2,7 +2,7 @@
 	<div class="pf-required-group pf-field pf-key-{{ data.key }}" data-key="{{ data.key }}">
 		<div class="pf-label">
 			<h3>{{ data.label }}</h3>
-			<# if ( data.value ) { #>
+			<# if ( data.value.length ) { #>
 				<div class="pf-all-good pf-status">
 					<span class="dashicons dashicons-yes"></span>
 				</div>
@@ -12,11 +12,11 @@
 				</div>
 			<# } #>
 		</div>
-		<# if ( data.value && data.showValue ) { #>
+		<# if ( data.value.length && data.showValue ) { #>
 			<div class="pf-value pf-has-value">
 				<p>{{ data.value }}</p>
 			</div>
-		<# } else if ( data.value && data.hasValue ) { #>
+		<# } else if ( data.value.length && data.hasValue ) { #>
 			<div class="pf-value pf-has-value">
 				<p>{{ data.hasValue }}</p>
 			</div>
@@ -24,7 +24,7 @@
 			<div class="pf-value pf-no-value">
 				<p>{{ data.noValue }}</p>
 			</div>
-		<# } else if ( data.value ) { #>
+		<# } else if ( data.value.length ) { #>
 			<div class="pf-value">
 				<p>Value: {{ data.value }}</p>
 			</div>

--- a/templates/required-meta.php
+++ b/templates/required-meta.php
@@ -2,7 +2,7 @@
 	<div class="pf-required-meta pf-field pf-key-{{ data.key }}" data-key="{{ data.key }}">
 		<div class="pf-label">
 			<h3>{{ data.label }}</h3>
-			<# if ( data.value ) { #>
+			<# if ( data.value.length ) { #>
 				<div class="pf-all-good pf-status">
 					<span class="dashicons dashicons-yes"></span>
 				</div>
@@ -12,11 +12,11 @@
 				</div>
 			<# } #>
 		</div>
-		<# if ( data.value && data.showValue ) { #>
+		<# if ( data.value.length && data.showValue ) { #>
 			<div class="pf-value pf-has-value">
 				<p>{{ data.value }}</p>
 			</div>
-		<# } else if ( data.value && data.hasValue ) { #>
+		<# } else if ( data.value.length && data.hasValue ) { #>
 			<div class="pf-value pf-has-value">
 				<p>{{ data.hasValue }}</p>
 			</div>
@@ -24,7 +24,7 @@
 			<div class="pf-value pf-no-value">
 				<p>{{ data.noValue }}</p>
 			</div>
-		<# } else if ( data.value ) { #>
+		<# } else if ( data.value.length ) { #>
 			<div class="pf-value">
 				<p>Value: {{ data.value }}</p>
 			</div>

--- a/templates/required-primary.php
+++ b/templates/required-primary.php
@@ -2,7 +2,7 @@
 	<div class="pf-required-primary pf-field pf-key-{{ data.key }}" data-key="{{ data.key }}">
 		<div class="pf-label">
 			<h3>{{ data.label }}</h3>
-			<# if ( data.value ) { #>
+			<# if ( data.value.length ) { #>
 				<div class="pf-all-good pf-status">
 					<span class="dashicons dashicons-yes"></span>
 				</div>
@@ -12,11 +12,11 @@
 				</div>
 			<# } #>
 		</div>
-		<# if ( data.value && data.showValue ) { #>
+		<# if ( data.value.length && data.showValue ) { #>
 			<div class="pf-value pf-has-value">
 				<p>{{ data.value }}</p>
 			</div>
-		<# } else if ( data.value && data.hasValue ) { #>
+		<# } else if ( data.value.length && data.hasValue ) { #>
 			<div class="pf-value pf-has-value">
 				<p>{{ data.hasValue }}</p>
 			</div>
@@ -24,7 +24,7 @@
 			<div class="pf-value pf-no-value">
 				<p>{{ data.noValue }}</p>
 			</div>
-		<# } else if ( data.value ) { #>
+		<# } else if ( data.value.length ) { #>
 			<div class="pf-value">
 				<p>Value: {{ data.value }}</p>
 			</div>

--- a/templates/required-taxonomy.php
+++ b/templates/required-taxonomy.php
@@ -2,7 +2,7 @@
 	<div class="pf-required-tax pf-field pf-key-{{ data.key }}" data-key="{{ data.key }}">
 		<div class="pf-label">
 			<h3>{{ data.label }}</h3>
-			<# if ( data.value ) { #>
+			<# if ( data.value.length ) { #>
 				<div class="pf-all-good pf-status">
 					<span class="dashicons dashicons-yes"></span>
 				</div>
@@ -12,11 +12,11 @@
 				</div>
 			<# } #>
 		</div>
-		<# if ( data.value && data.showValue ) { #>
+		<# if ( data.value.length && data.showValue ) { #>
 			<div class="pf-value pf-has-value">
 				<p>{{ data.value }}</p>
 			</div>
-		<# } else if ( data.value && data.hasValue ) { #>
+		<# } else if ( data.value.length && data.hasValue ) { #>
 			<div class="pf-value pf-has-value">
 				<p>{{ data.hasValue }}</p>
 			</div>
@@ -24,7 +24,7 @@
 			<div class="pf-value pf-no-value">
 				<p>{{ data.noValue }}</p>
 			</div>
-		<# } else if ( data.value ) { #>
+		<# } else if ( data.value.length ) { #>
 			<div class="pf-value">
 				<p>Value: {{ data.value }}</p>
 			</div>


### PR DESCRIPTION
Currently, some fields will always show true even if they haven't been set and are empty. This happens on fields that can have multiple values such as "Category". In JavaScript, an empty array will show as truthy which is breaking these checks.