### PR TITLE
Fix bug where stale post object could get passed into wp_publish_post, and cut v1.1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Tags:** publishing, flow, required, fields, preview  
 **Requires at least:** 4.5  
 **Tested up to:** 4.6  
-**Stable tag:** 1.1.5  
+**Stable tag:** 1.1.6  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -225,6 +225,9 @@ function xxx_data_array( $data ) {
 
 ## Changelog ##
 
+### 1.1.6 ###
+* Fix bug where stale Post object would get passed into wp_publish_post.
+
 ### 1.1.5 ###
 * Fix bug where the link back to the edit screen would be incorrect when the Ajax request to publish a Post would fail.
 
@@ -249,6 +252,9 @@ function xxx_data_array( $data ) {
 * Initial release.
 
 ## Upgrade Notice ##
+
+### 1.1.6 ###
+* Fix bug where stale Post object would get passed into wp_publish_post.
 
 ### 1.1.5 ###
 * Fix bug where the link back to the edit screen would be incorrect when the Ajax request to publish a Post would fail.

--- a/inc/class-publishing-flow-admin.php
+++ b/inc/class-publishing-flow-admin.php
@@ -968,9 +968,15 @@ class Publishing_Flow_Admin {
 				$_POST['aa'] = substr( $post->post_date, 0, 4 );
 
 				wp_update_post( $post );
+
+				// Refresh the post object, as the call to `wp_update_post` might have mutated it.
+				$post = get_post( $post->ID );
 			}
 
 			wp_publish_post( $post );
+
+			// Refresh the post object, as the call to `wp_publish_post` will have mutated it.
+			$post = get_post( $post->ID );
 
 			$outcome = 'published';
 		}

--- a/languages/publishing-flow.pot
+++ b/languages/publishing-flow.pot
@@ -2,9 +2,9 @@
 # This file is distributed under the same license as the Publishing Flow package.
 msgid ""
 msgstr ""
-"Project-Id-Version: Publishing Flow 1.1.5\n"
+"Project-Id-Version: Publishing Flow 1.1.6\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/publishing-flow\n"
-"POT-Creation-Date: 2019-03-21 01:22:14+00:00\n"
+"POT-Creation-Date: 2019-07-12 21:17:17+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -160,27 +160,27 @@ msgstr ""
 msgid "Looks like this post has already been published or scheduled"
 msgstr ""
 
-#: inc/class-publishing-flow-admin.php:1004
+#: inc/class-publishing-flow-admin.php:1010
 msgid "Post Title"
 msgstr ""
 
-#: inc/class-publishing-flow-admin.php:1006
+#: inc/class-publishing-flow-admin.php:1012
 msgid "The post has a title"
 msgstr ""
 
-#: inc/class-publishing-flow-admin.php:1007
+#: inc/class-publishing-flow-admin.php:1013
 msgid "The post is missing a title"
 msgstr ""
 
-#: inc/class-publishing-flow-admin.php:1010
+#: inc/class-publishing-flow-admin.php:1016
 msgid "Post Content"
 msgstr ""
 
-#: inc/class-publishing-flow-admin.php:1012
+#: inc/class-publishing-flow-admin.php:1018
 msgid "The post has content"
 msgstr ""
 
-#: inc/class-publishing-flow-admin.php:1013
+#: inc/class-publishing-flow-admin.php:1019
 msgid "The post is missing content"
 msgstr ""
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "publishing-flow",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "main": "Gruntfile.js",
   "author": "Braad Martin",
   "devDependencies": {

--- a/publishing-flow.php
+++ b/publishing-flow.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Publishing Flow
- * Version:     1.1.5
+ * Version:     1.1.6
  * Description: Adds a Customizer-based publishing flow for ensuring posts are complete before publishing
  * Author:      Braad Martin
  * Author URI:  http://braadmartin.com
@@ -10,7 +10,7 @@
  * Domain Path: /languages
  */
 
-define( 'PUBLISHING_FLOW_VERSION', '1.1.5' );
+define( 'PUBLISHING_FLOW_VERSION', '1.1.6' );
 define( 'PUBLISHING_FLOW_PATH', plugin_dir_path( __FILE__ ) );
 define( 'PUBLISHING_FLOW_URL', plugin_dir_url( __FILE__ ) );
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: http://braadmartin.com/
 Tags: publishing, flow, required, fields, preview
 Requires at least: 4.5
 Tested up to: 4.6
-Stable tag: 1.1.5
+Stable tag: 1.1.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -225,6 +225,9 @@ function xxx_data_array( $data ) {
 
 == Changelog ==
 
+= 1.1.6 =
+* Fix bug where stale Post object would get passed into wp_publish_post.
+
 = 1.1.5 =
 * Fix bug where the link back to the edit screen would be incorrect when the Ajax request to publish a Post would fail.
 
@@ -249,6 +252,9 @@ function xxx_data_array( $data ) {
 * Initial release.
 
 == Upgrade Notice ==
+
+= 1.1.6 =
+* Fix bug where stale Post object would get passed into wp_publish_post.
 
 = 1.1.5 =
 * Fix bug where the link back to the edit screen would be incorrect when the Ajax request to publish a Post would fail.


### PR DESCRIPTION
This change fixes a bug where a stale post object would get passed into `wp_publish_post` under specific circumstances.