### PR TITLE
Fix bug where published posts could end up with empty slugs, and bump to 1.1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Tags:** publishing, flow, required, fields, preview  
 **Requires at least:** 4.5  
 **Tested up to:** 4.9  
-**Stable tag:** 1.1.7  
+**Stable tag:** 1.1.8  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -159,10 +159,7 @@ add_filter( 'publishing_flow_dev_domain', 'xxx_dev_domain' );
  * @return  string           Our dev domain.
  */
 function xxx_dev_domain( $domain ) {
-
-	$domain = 'local.wordpress.dev';
-
-	return $domain;
+	return 'local.wordpress.dev';
 }
 ```
 
@@ -216,7 +213,6 @@ add_filter( 'publishing_flow_data_array', 'xxx_data_array' );
  * @return  array         The updated data array.
  */
 function xxx_data_array( $data ) {
-
 	$data['defaultDevice'] = 'tablet';
 
 	return $data;
@@ -225,8 +221,11 @@ function xxx_data_array( $data ) {
 
 ## Changelog ##
 
+### 1.1.8 ###
+* Bugfix to prevent it being possible to publish posts with an empty slug.
+
 ### 1.1.7 ###
-* Small CSS change to support WP 4.9
+* Small CSS change to support WP 4.9.
 
 ### 1.1.6 ###
 * Fix bug where stale Post object would get passed into wp_publish_post.
@@ -256,8 +255,11 @@ function xxx_data_array( $data ) {
 
 ## Upgrade Notice ##
 
+### 1.1.8 ###
+* Bugfix to prevent it being possible to publish posts with an empty slug.
+
 ### 1.1.7 ###
-* Small CSS change to support WP 4.9
+* Small CSS change to support WP 4.9.
 
 ### 1.1.6 ###
 * Fix bug where stale Post object would get passed into wp_publish_post.

--- a/languages/publishing-flow.pot
+++ b/languages/publishing-flow.pot
@@ -1,14 +1,14 @@
-# Copyright (C) 2019 Braad Martin
+# Copyright (C) 2020 Braad Martin
 # This file is distributed under the same license as the Publishing Flow package.
 msgid ""
 msgstr ""
-"Project-Id-Version: Publishing Flow 1.1.7\n"
+"Project-Id-Version: Publishing Flow 1.1.8\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/publishing-flow\n"
-"POT-Creation-Date: 2019-10-29 21:18:18+00:00\n"
+"POT-Creation-Date: 2020-08-21 21:34:02+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2019-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2020-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "X-Generator: grunt-wp-i18n 0.5.4\n"
@@ -160,27 +160,27 @@ msgstr ""
 msgid "Looks like this post has already been published or scheduled"
 msgstr ""
 
-#: inc/class-publishing-flow-admin.php:1010
+#: inc/class-publishing-flow-admin.php:1029
 msgid "Post Title"
 msgstr ""
 
-#: inc/class-publishing-flow-admin.php:1012
+#: inc/class-publishing-flow-admin.php:1031
 msgid "The post has a title"
 msgstr ""
 
-#: inc/class-publishing-flow-admin.php:1013
+#: inc/class-publishing-flow-admin.php:1032
 msgid "The post is missing a title"
 msgstr ""
 
-#: inc/class-publishing-flow-admin.php:1016
+#: inc/class-publishing-flow-admin.php:1035
 msgid "Post Content"
 msgstr ""
 
-#: inc/class-publishing-flow-admin.php:1018
+#: inc/class-publishing-flow-admin.php:1037
 msgid "The post has content"
 msgstr ""
 
-#: inc/class-publishing-flow-admin.php:1019
+#: inc/class-publishing-flow-admin.php:1038
 msgid "The post is missing content"
 msgstr ""
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "publishing-flow",
-  "version": "1.1.6",
+  "version": "1.1.8",
   "main": "Gruntfile.js",
   "author": "Braad Martin",
   "devDependencies": {

--- a/publishing-flow.php
+++ b/publishing-flow.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Publishing Flow
- * Version:     1.1.7
+ * Version:     1.1.8
  * Description: Adds a Customizer-based publishing flow for ensuring posts are complete before publishing
  * Author:      Braad Martin
  * Author URI:  http://braadmartin.com
@@ -10,7 +10,7 @@
  * Domain Path: /languages
  */
 
-define( 'PUBLISHING_FLOW_VERSION', '1.1.7' );
+define( 'PUBLISHING_FLOW_VERSION', '1.1.8' );
 define( 'PUBLISHING_FLOW_PATH', plugin_dir_path( __FILE__ ) );
 define( 'PUBLISHING_FLOW_URL', plugin_dir_url( __FILE__ ) );
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: http://braadmartin.com/
 Tags: publishing, flow, required, fields, preview
 Requires at least: 4.5
 Tested up to: 4.9
-Stable tag: 1.1.7
+Stable tag: 1.1.8
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -159,10 +159,7 @@ add_filter( 'publishing_flow_dev_domain', 'xxx_dev_domain' );
  * @return  string           Our dev domain.
  */
 function xxx_dev_domain( $domain ) {
-
-	$domain = 'local.wordpress.dev';
-
-	return $domain;
+	return 'local.wordpress.dev';
 }
 ```
 
@@ -216,7 +213,6 @@ add_filter( 'publishing_flow_data_array', 'xxx_data_array' );
  * @return  array         The updated data array.
  */
 function xxx_data_array( $data ) {
-
 	$data['defaultDevice'] = 'tablet';
 
 	return $data;
@@ -224,6 +220,9 @@ function xxx_data_array( $data ) {
 ```
 
 == Changelog ==
+
+= 1.1.8 =
+* Bugfix to prevent it being possible to publish posts with an empty slug.
 
 = 1.1.7 =
 * Small CSS change to support WP 4.9.
@@ -255,6 +254,9 @@ function xxx_data_array( $data ) {
 * Initial release.
 
 == Upgrade Notice ==
+
+= 1.1.8 =
+* Bugfix to prevent it being possible to publish posts with an empty slug.
 
 = 1.1.7 =
 * Small CSS change to support WP 4.9.


### PR DESCRIPTION
Previously it was possible for a post published through publishing flow to end up with an empty slug. This PR fixes this issue by forcing a refresh of the slug if it's detected as empty before publishing the post.